### PR TITLE
Setting up art package auto-pipeline

### DIFF
--- a/Assets/Editor/InvictusArtAutoUpdater.cs
+++ b/Assets/Editor/InvictusArtAutoUpdater.cs
@@ -1,0 +1,145 @@
+using System.IO;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
+using UnityEngine;
+
+[InitializeOnLoad]
+public static class InvictusArtAutoUpdater
+{
+    private const string PrefKey = "InvictusArt.AutoUpdateOnLaunch";
+    private const string PackageName = "com.invictus.art";
+
+    private const string PackageUrl =
+        "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets#main";
+
+    private static AddRequest _addRequest;
+    private static bool _started;
+    private static string _revisionBefore;
+
+    static InvictusArtAutoUpdater()
+    {
+        if (!EditorPrefs.HasKey(PrefKey))
+            EditorPrefs.SetBool(PrefKey, true);
+
+        EditorApplication.delayCall += TryAutoUpdateOnce;
+    }
+
+    // Toggle
+    [MenuItem("Tools/Packages/Invictus Art/Auto-update on launch")]
+    private static void Toggle()
+    {
+        bool enabled = EditorPrefs.GetBool(PrefKey, true);
+        EditorPrefs.SetBool(PrefKey, !enabled);
+    }
+
+    [MenuItem("Tools/Packages/Invictus Art/Auto-update on launch", true)]
+    private static bool ToggleValidate()
+    {
+        Menu.SetChecked("Tools/Packages/Invictus Art/Auto-update on launch",
+            EditorPrefs.GetBool(PrefKey, true));
+        return true;
+    }
+
+    // Manual update
+    [MenuItem("Tools/Packages/Invictus Art/Update now")]
+    private static void UpdateNow()
+    {
+        StartUpdate();
+    }
+
+    private static void TryAutoUpdateOnce()
+    {
+        if (_started) return;
+        _started = true;
+
+        if (!EditorPrefs.GetBool(PrefKey, true))
+            return;
+
+        if (Application.isBatchMode)
+            return;
+
+        if (EditorApplication.isPlayingOrWillChangePlaymode || EditorApplication.isCompiling)
+        {
+            EditorApplication.delayCall += TryAutoUpdateOnce;
+            return;
+        }
+
+        _revisionBefore = GetLockedRevision();
+        Debug.Log("Invictus Art: Checking for updates...");
+        StartUpdate();
+    }
+
+    private static void StartUpdate()
+    {
+        _addRequest = Client.Add(PackageUrl);
+        EditorApplication.update += PollAdd;
+    }
+
+    private static void PollAdd()
+    {
+        if (_addRequest == null || !_addRequest.IsCompleted) return;
+
+        EditorApplication.update -= PollAdd;
+
+        if (_addRequest.Status == StatusCode.Success)
+        {
+            string after = GetLockedRevision();
+
+            if (_revisionBefore != after)
+            {
+                ShowNotification(after);
+                Debug.Log($"Invictus Art updated → {Short(_revisionBefore)} → {Short(after)}");
+            }
+            else
+            {
+                Debug.Log("Invictus Art already up to date.");
+            }
+        }
+        else
+        {
+            Debug.LogError("Invictus Art update failed: " + _addRequest.Error.message);
+        }
+
+        _addRequest = null;
+    }
+
+    private static void ShowNotification(string revision)
+    {
+        EditorApplication.delayCall += () =>
+        {
+            var window = EditorWindow.focusedWindow;
+            if (window != null)
+                window.ShowNotification(new GUIContent($"Art package updated ({Short(revision)})"));
+
+            // clicking console entry shows details
+            Debug.Log($"Invictus Art revision: {revision}");
+        };
+    }
+
+    private static string GetLockedRevision()
+    {
+        string lockPath = Path.Combine(Directory.GetCurrentDirectory(), "Packages", "packages-lock.json");
+        if (!File.Exists(lockPath)) return null;
+
+        string json = File.ReadAllText(lockPath);
+        string marker = $"\"{PackageName}\"";
+
+        int start = json.IndexOf(marker);
+        if (start == -1) return null;
+
+        int revIndex = json.IndexOf("\"revision\"", start);
+        if (revIndex == -1) return null;
+
+        int quote = json.IndexOf('"', revIndex + 10);
+        int end = json.IndexOf('"', quote + 1);
+
+        return json.Substring(quote + 1, end - quote - 1);
+    }
+
+    private static string Short(string sha)
+    {
+        if (string.IsNullOrEmpty(sha)) return "(none)";
+        return sha.Length <= 8 ? sha : sha.Substring(0, 8);
+    }
+}

--- a/Assets/Editor/InvictusArtAutoUpdater.cs
+++ b/Assets/Editor/InvictusArtAutoUpdater.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEditor.PackageManager;
@@ -10,12 +12,15 @@ public static class InvictusArtAutoUpdater
     private const string PrefKey = "InvictusArt.AutoUpdateOnLaunch";
     private const string PackageName = "com.invictus.art";
 
+    // Must match your manifest entry
     private const string PackageUrl =
         "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets#main";
 
     private static AddRequest _addRequest;
     private static bool _started;
-    private static string _revisionBefore;
+
+    private static string _revBefore;
+    private static HashSet<string> _filesBefore;
 
     static InvictusArtAutoUpdater()
     {
@@ -25,7 +30,6 @@ public static class InvictusArtAutoUpdater
         EditorApplication.delayCall += TryAutoUpdateOnce;
     }
 
-    // Toggle
     [MenuItem("Tools/Packages/Invictus Art/Auto-update on launch")]
     private static void Toggle()
     {
@@ -41,10 +45,10 @@ public static class InvictusArtAutoUpdater
         return true;
     }
 
-    // Manual update
     [MenuItem("Tools/Packages/Invictus Art/Update now")]
     private static void UpdateNow()
     {
+        CaptureBeforeState();
         StartUpdate();
     }
 
@@ -53,21 +57,25 @@ public static class InvictusArtAutoUpdater
         if (_started) return;
         _started = true;
 
-        if (!EditorPrefs.GetBool(PrefKey, true))
-            return;
+        if (!EditorPrefs.GetBool(PrefKey, true)) return;
+        if (Application.isBatchMode) return;
 
-        if (Application.isBatchMode)
-            return;
-
+        // Avoid updating during compile/playmode; retry next tick.
         if (EditorApplication.isPlayingOrWillChangePlaymode || EditorApplication.isCompiling)
         {
             EditorApplication.delayCall += TryAutoUpdateOnce;
             return;
         }
 
-        _revisionBefore = GetLockedRevision();
-        Debug.Log("Invictus Art: Checking for updates...");
+        CaptureBeforeState();
+        Debug.Log($"Invictus Art: Checking for updates... (before rev: {Short(_revBefore)})");
         StartUpdate();
+    }
+
+    private static void CaptureBeforeState()
+    {
+        _revBefore = GetLockedRevisionSafe(PackageName);
+        _filesBefore = SnapshotPackageFiles(PackageName);
     }
 
     private static void StartUpdate()
@@ -82,64 +90,153 @@ public static class InvictusArtAutoUpdater
 
         EditorApplication.update -= PollAdd;
 
-        if (_addRequest.Status == StatusCode.Success)
-        {
-            string after = GetLockedRevision();
-
-            if (_revisionBefore != after)
-            {
-                ShowNotification(after);
-                Debug.Log($"Invictus Art updated → {Short(_revisionBefore)} → {Short(after)}");
-            }
-            else
-            {
-                Debug.Log("Invictus Art already up to date.");
-            }
-        }
-        else
+        if (_addRequest.Status != StatusCode.Success)
         {
             Debug.LogError("Invictus Art update failed: " + _addRequest.Error.message);
+            ShowNotification("Art package update FAILED (see Console)");
+            _addRequest = null;
+            return;
         }
 
+        // Give Unity a moment to write packages-lock.json / refresh PackageCache
+        EditorApplication.delayCall += OnUpdateFinished;
         _addRequest = null;
     }
 
-    private static void ShowNotification(string revision)
+    private static void OnUpdateFinished()
+    {
+        string revAfter = GetLockedRevisionSafe(PackageName);
+        var filesAfter = SnapshotPackageFiles(PackageName);
+
+        Debug.Log($"Invictus Art: resolved rev {Short(_revBefore)} → {Short(revAfter)}");
+
+        var added = new List<string>();
+        var removed = new List<string>();
+
+        if (_filesBefore != null && filesAfter != null)
+        {
+            foreach (var f in filesAfter)
+                if (!_filesBefore.Contains(f)) added.Add(f);
+
+            foreach (var f in _filesBefore)
+                if (!filesAfter.Contains(f)) removed.Add(f);
+        }
+
+        bool changed = !StringEquals(_revBefore, revAfter) || added.Count > 0 || removed.Count > 0;
+
+        if (!changed)
+        {
+            Debug.Log("Invictus Art already up to date.");
+            return;
+        }
+
+        Debug.Log($"Invictus Art updated. Added: {added.Count}, Removed: {removed.Count}");
+
+        foreach (var a in Limit(added, 25)) Debug.Log("  + " + a);
+        foreach (var r in Limit(removed, 25)) Debug.Log("  - " + r);
+
+        if (added.Count > 25 || removed.Count > 25)
+            Debug.Log($"(Showing up to 25 of each. Total Added={added.Count}, Removed={removed.Count})");
+
+        ShowNotification($"Art package updated ({Short(revAfter)})");
+    }
+
+    private static HashSet<string> SnapshotPackageFiles(string packageName)
+    {
+        try
+        {
+            string rev = GetLockedRevisionSafe(packageName);
+            if (string.IsNullOrEmpty(rev)) return null;
+
+            string cacheRoot = Path.Combine(Directory.GetCurrentDirectory(), "Library", "PackageCache");
+            if (!Directory.Exists(cacheRoot)) return null;
+
+            string prefix = packageName + "@";
+            var dirs = Directory.GetDirectories(cacheRoot, prefix + "*");
+            if (dirs.Length == 0) return null;
+
+            string pkgDir = dirs[0];
+            DateTime best = Directory.GetLastWriteTimeUtc(pkgDir);
+            for (int i = 1; i < dirs.Length; i++)
+            {
+                var t = Directory.GetLastWriteTimeUtc(dirs[i]);
+                if (t > best) { best = t; pkgDir = dirs[i]; }
+            }
+
+            var set = new HashSet<string>();
+            foreach (var file in Directory.GetFiles(pkgDir, "*", SearchOption.AllDirectories))
+            {
+                var rel = file.Substring(pkgDir.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                set.Add(rel.Replace('\\', '/'));
+            }
+            return set;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string GetLockedRevisionSafe(string packageName)
+    {
+        string lockPath = Path.Combine(Directory.GetCurrentDirectory(), "Packages", "packages-lock.json");
+        if (!File.Exists(lockPath))
+            return null;
+
+        string json = File.ReadAllText(lockPath);
+
+        int pkgIndex = json.IndexOf($"\"{packageName}\"", StringComparison.Ordinal);
+        if (pkgIndex < 0) return null;
+
+        // Try revision first
+        string value = ExtractValue(json, pkgIndex, "revision");
+        if (!string.IsNullOrEmpty(value))
+            return value;
+
+        // Fallback to hash (Git packages)
+        value = ExtractValue(json, pkgIndex, "hash");
+        if (!string.IsNullOrEmpty(value))
+            return value;
+
+        return null;
+    }
+
+    private static string ExtractValue(string json, int startIndex, string key)
+    {
+        int keyIndex = json.IndexOf($"\"{key}\"", startIndex, StringComparison.Ordinal);
+        if (keyIndex < 0) return null;
+
+        int colon = json.IndexOf(':', keyIndex);
+        if (colon < 0) return null;
+
+        int q1 = json.IndexOf('"', colon + 1);
+        if (q1 < 0) return null;
+
+        int q2 = json.IndexOf('"', q1 + 1);
+        if (q2 < 0) return null;
+
+        return json.Substring(q1 + 1, q2 - q1 - 1);
+    }
+
+    private static void ShowNotification(string text)
     {
         EditorApplication.delayCall += () =>
         {
             var window = EditorWindow.focusedWindow;
             if (window != null)
-                window.ShowNotification(new GUIContent($"Art package updated ({Short(revision)})"));
-
-            // clicking console entry shows details
-            Debug.Log($"Invictus Art revision: {revision}");
+                window.ShowNotification(new GUIContent(text));
         };
     }
 
-    private static string GetLockedRevision()
+    private static IEnumerable<string> Limit(List<string> list, int max)
     {
-        string lockPath = Path.Combine(Directory.GetCurrentDirectory(), "Packages", "packages-lock.json");
-        if (!File.Exists(lockPath)) return null;
-
-        string json = File.ReadAllText(lockPath);
-        string marker = $"\"{PackageName}\"";
-
-        int start = json.IndexOf(marker);
-        if (start == -1) return null;
-
-        int revIndex = json.IndexOf("\"revision\"", start);
-        if (revIndex == -1) return null;
-
-        int quote = json.IndexOf('"', revIndex + 10);
-        int end = json.IndexOf('"', quote + 1);
-
-        return json.Substring(quote + 1, end - quote - 1);
+        int n = Mathf.Min(max, list.Count);
+        for (int i = 0; i < n; i++) yield return list[i];
     }
 
-    private static string Short(string sha)
-    {
-        if (string.IsNullOrEmpty(sha)) return "(none)";
-        return sha.Length <= 8 ? sha : sha.Substring(0, 8);
-    }
+    private static bool StringEquals(string a, string b) =>
+        string.Equals(a ?? "", b ?? "", StringComparison.OrdinalIgnoreCase);
+
+    private static string Short(string sha) =>
+        string.IsNullOrEmpty(sha) ? "(none)" : (sha.Length <= 8 ? sha : sha.Substring(0, 8));
 }

--- a/Assets/Editor/InvictusArtAutoUpdater.cs.meta
+++ b/Assets/Editor/InvictusArtAutoUpdater.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa9c59f9c0e60734bbae7af52a62edcb

--- a/Kicklings.slnx
+++ b/Kicklings.slnx
@@ -62,12 +62,12 @@
   <Project Path="Unity.2D.Animation.Runtime.csproj" />
   <Project Path="Unity.Mathematics.Editor.csproj" />
   <Project Path="Unity.VisualScripting.SettingsProvider.Editor.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
   <Project Path="Coffee.UIParticle.Editor.csproj" />
   <Project Path="Unity.InputSystem.TestFramework.csproj" />
   <Project Path="Unity.CollabProxy.Editor.csproj" />
   <Project Path="Unity.ShaderGraph.Utilities.csproj" />
   <Project Path="Unity.VisualScripting.Shared.Editor.csproj" />
-  <Project Path="Assembly-CSharp-Editor.csproj" />
   <Project Path="Assembly-CSharp-Editor-firstpass.csproj" />
   <Project Path="Unity.RenderPipeline.Universal.ShaderLibrary.csproj" />
   <Project Path="Unity.2D.Common.Runtime.csproj" />

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.invictus.art": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/RuntimeAssets#main",
+    "com.invictus.art": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets#main",
     "com.coffee.ui-particle": "https://github.com/mob-sakai/ParticleEffectForUGUI.git",
     "com.unity.collab-proxy": "2.10.2",
     "com.unity.feature.2d": "2.0.1",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.invictus.art": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/RuntimeAssets#main",
     "com.coffee.ui-particle": "https://github.com/mob-sakai/ParticleEffectForUGUI.git",
     "com.unity.collab-proxy": "2.10.2",
     "com.unity.feature.2d": "2.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,6 +10,13 @@
       },
       "hash": "4b98abd7469b10d55c9c623830cb6e1518f72731"
     },
+    "com.invictus.art": {
+      "version": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets#main",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "ebd3160ef3d62c47aa10fb70c023ed6e0a44dd1c"
+    },
     "com.unity.2d.animation": {
       "version": "10.2.2",
       "depth": 1,


### PR DESCRIPTION
Most of the configuration is already done on the Kickling-Art repo side. **This PR was created so that we can merge only when we are ready.**

In Kickling-Art, all assets that need to be shared should be under the 'Runtime Assets' folder. If we want to use some other approach, we should discuss and edit this file before merging. 

The one caveat -- it's not possible to transfer 'all' files from the art repo to the main, because some are editor files that would cause compilation errors. This is the main reason for the separate 'RuntimeAssets' folder. 

**On the art side:**
<img width="603" height="261" alt="image" src="https://github.com/user-attachments/assets/30133c09-87b9-439b-b280-38c9000cd75a" />

**On the game side:**
<img width="394" height="210" alt="image" src="https://github.com/user-attachments/assets/95f574f4-c7d2-4b22-9be5-de33b7f282cd" />

Update: The tool now auto-fetches the latest updated package from the art repo, as intended. This can be disabled on the game repo if we ever encounter issues. If its disabled, we'll need to click 'update' manually in the package manager. But if we don't encounter any issues, it will be automatic!