### PR TITLE
Art Pipeline Update - Updated main branch to use invictus.art.common for common assets

### DIFF
--- a/Assets/Editor/InvictusArtAutoUpdater.cs
+++ b/Assets/Editor/InvictusArtAutoUpdater.cs
@@ -10,11 +10,11 @@ using UnityEngine;
 public static class InvictusArtAutoUpdater
 {
     private const string PrefKey = "InvictusArt.AutoUpdateOnLaunch";
-    private const string PackageName = "com.invictus.art";
+    private const string PackageName = "com.invictus.art.common";
 
     // Must match your manifest entry
     private const string PackageUrl =
-        "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets#main";
+        "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets/Common#main";
 
     private static AddRequest _addRequest;
     private static bool _started;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.invictus.art": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets#main",
+    "com.invictus.art.common": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets/Common#main",
     "com.coffee.ui-particle": "https://github.com/mob-sakai/ParticleEffectForUGUI.git",
     "com.unity.collab-proxy": "2.10.2",
     "com.unity.feature.2d": "2.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,8 +10,8 @@
       },
       "hash": "4b98abd7469b10d55c9c623830cb6e1518f72731"
     },
-    "com.invictus.art": {
-      "version": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets#main",
+    "com.invictus.art.common": {
+      "version": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets/Common#main",
       "depth": 0,
       "source": "git",
       "dependencies": {},


### PR DESCRIPTION
<img width="165" height="85" alt="image" src="https://github.com/user-attachments/assets/97de07ca-c90b-45de-bbff-c76e18a45163" />

This change is part of a restructuring that separates the pipeline into 3 packages (and 3 folders on the art side as depicted) to organize for different branches.

Ultimately, if we ever merge campaign and tournament branches into main -- that would require a small change to this pipeline. 

But for now, as long as we merge tournament changes into tournament, and campaign changes into campaign, it should be good. 