### PR TITLE
Dynamic difficulty and changed tournaments goals required to 3

### DIFF
--- a/Assets/GameAndPlayerData.cs
+++ b/Assets/GameAndPlayerData.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+
+public class GameAndPlayerData : MonoBehaviour
+{
+    public int numGamesPlayed { get; set; }
+    public int numGamesWon { get; set; }
+    public int numGamesLost { get; set; }
+    public int numTournamentMatchesPlayed { get; set; }
+    public int numTournamentMatchesWon { get; set; }
+    public int numTournamentMatchesLost { get; set; }
+    public int numSessionsPlayed { get; set; }
+    public float totalPlaytime { get; set; }
+
+    public int numGamesPlayedToday { get; set; }
+    public int numGamesWonToday { get; set; }
+    public int numGamesLostToday { get; set; }
+    public int numTournamentMatchesPlayedToday { get; set; }
+    public int numTournamentMatchesWonToday { get; set; }
+    public int numTournamentMatchesLostToday { get; set; }
+    public float totalPlaytimeToday() => Time.time;
+
+    // Persistent ELO rating. Nudges toward each game result with the eloInc. Starts at 0.35 and saved across sessions.
+    private float eloT = 0.35f;
+    private const float eloInc = 0.1f;
+    public void UpdateElo(bool won)
+    {
+        float outcome = won ? 1f : 0f;
+        eloT += eloInc * (outcome - eloT);
+    }
+
+    // Skill rating: 0 = weakest, 1 = strongest. Starts at 0.35 with no data.
+    // Blends the persistent ELO signal with today's Bayesian win rate. Today's weight depends on how many games you played today.
+    public float T
+    {
+        get
+        {
+            int playedToday = numGamesPlayedToday + numTournamentMatchesPlayedToday;
+            int wonToday = numGamesWonToday    + numTournamentMatchesWonToday;
+            float todayRate = (wonToday + 1.75f) / (playedToday + 5f);
+            float todayWeight = playedToday / (playedToday + 5f);
+            return Mathf.Lerp(eloT, todayRate, todayWeight);
+        }
+    }
+
+    public static GameAndPlayerData Instance;
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    private void Start()
+    {
+        numGamesPlayedToday = 0;
+        numGamesLostToday = 0;
+        numGamesWonToday = 0;
+        numTournamentMatchesPlayedToday = 0;
+        numTournamentMatchesLostToday = 0;
+        numTournamentMatchesWonToday = 0;
+
+        // Cross-play-session data is saved and loaded to player prefs
+        eloT = PlayerPrefs.GetFloat("eloT", 0.35f);
+        numGamesPlayed = PlayerPrefs.GetInt("numGamesPlayed", 0);
+        numGamesLost = PlayerPrefs.GetInt("numGamesLost", 0);
+        numGamesWon = PlayerPrefs.GetInt("numGamesWon", 0);
+        numTournamentMatchesPlayed = PlayerPrefs.GetInt("numTournamentMatchesPlayed", 0);
+        numTournamentMatchesLost = PlayerPrefs.GetInt("numTournamentMatchesLost", 0);
+        numTournamentMatchesWon = PlayerPrefs.GetInt("numTournamentMatchesWon", 0);
+    }
+
+    private void OnApplicationQuit()
+    {
+        // Save cross-play-session data to player prefs
+        PlayerPrefs.SetFloat("eloT", eloT);
+        PlayerPrefs.SetInt("numGamesPlayed", numGamesPlayed);
+        PlayerPrefs.SetInt("numGamesLost", numGamesLost);
+        PlayerPrefs.SetInt("numGamesWon", numGamesWon);
+        PlayerPrefs.SetInt("numTournamentMatchesPlayed", numTournamentMatchesPlayed);
+        PlayerPrefs.SetInt("numTournamentMatchesLost", numTournamentMatchesLost);
+        PlayerPrefs.SetInt("numTournamentMatchesWon", numTournamentMatchesWon);
+    }
+}

--- a/Assets/GameAndPlayerData.cs.meta
+++ b/Assets/GameAndPlayerData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c5fbafc46ab62b74aae66e7f04fbf0d2

--- a/Assets/Prefabs/PersistentObjects.prefab
+++ b/Assets/Prefabs/PersistentObjects.prefab
@@ -1,5 +1,49 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2059283927596459328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4165298672119615925}
+  - component: {fileID: 7777393436564981447}
+  m_Layer: 0
+  m_Name: GameAndPlayerData
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4165298672119615925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2059283927596459328}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8703303136494428086}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7777393436564981447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2059283927596459328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5fbafc46ab62b74aae66e7f04fbf0d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2682249539236510962
 GameObject:
   m_ObjectHideFlags: 0
@@ -32,6 +76,7 @@ Transform:
   m_Children:
   - {fileID: 9148108211230182708}
   - {fileID: 1292664567035427746}
+  - {fileID: 4165298672119615925}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6919742171775934926

--- a/Assets/Scripts/Gameplay/Managers/MatchManager.cs
+++ b/Assets/Scripts/Gameplay/Managers/MatchManager.cs
@@ -21,6 +21,7 @@ namespace Gameplay.Managers
         [SerializeField] FieldSideData _rightSideData;
         
         Match _match;
+        float _matchStartTime;
 
         int _leftScore, _rightScore;
         public void ResetGame()
@@ -58,6 +59,7 @@ namespace Gameplay.Managers
             _goalsManager?.SetCollidersEnabled(true);
             _leftScore = 0;
             _rightScore = 0;
+            _matchStartTime = Time.time;
             TimeScaleManager.SetGameplayTimeScale();
         }
     
@@ -123,6 +125,26 @@ namespace Gameplay.Managers
 
             _playersManager.DisablePlayers();
             _match.HandleEndgameUI(this, _uiManager, payload);
+
+            var data = GameAndPlayerData.Instance;
+            if (data != null)
+            {
+                data.numGamesPlayed++;
+                data.numGamesPlayedToday++;
+                data.totalPlaytime += Time.time - _matchStartTime;
+
+                if (_match.IsPlayerWinner)
+                {
+                    data.numGamesWon++;
+                    data.numGamesWonToday++;
+                }
+                else
+                {
+                    data.numGamesLost++;
+                    data.numGamesLostToday++;
+                }
+                data.UpdateElo(_match.IsPlayerWinner);
+            }
         }
 
         public void InstantWin()

--- a/Assets/Scripts/Scene Management/Match.cs
+++ b/Assets/Scripts/Scene Management/Match.cs
@@ -53,6 +53,24 @@ namespace Scene_Management
         {
             IsPlayerWinner = goalEvent.ScoringSideData.SideType == FieldSideType.Left;
 
+            var data = GameAndPlayerData.Instance;
+            if (data != null)
+            {
+                data.numTournamentMatchesPlayed++;
+                data.numTournamentMatchesPlayedToday++;
+
+                if (IsPlayerWinner)
+                {
+                    data.numTournamentMatchesWon++;
+                    data.numTournamentMatchesWonToday++;
+                }
+                else
+                {
+                    data.numTournamentMatchesLost++;
+                    data.numTournamentMatchesLostToday++;
+                }
+            }
+
             if (!IsPlayerWinner)
                 uiManager.ShowTournamentKnockOutView();
             else if (_tournament.CurrentRound.IsLastRound())

--- a/Assets/Scripts/UI/MainMenu/StartTournamentAfterCutscene.cs
+++ b/Assets/Scripts/UI/MainMenu/StartTournamentAfterCutscene.cs
@@ -57,5 +57,5 @@ public class StartTournamentAfterCutscene : MonoBehaviour
 
     public static float RandomSkinTone() => Random.Range(0, 1.0f);
     public const bool isTournamentMatch = true;
-    public const int goalsToEndMatch = 5;
+    public const int goalsToEndMatch = 3;
 }

--- a/Assets/Scripts/UI/MainMenu/TournamentMode/Tournament.cs
+++ b/Assets/Scripts/UI/MainMenu/TournamentMode/Tournament.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using CommonDataTypes;
 using Gameplay.CharacterComponents.Cpu;
+using UnityEngine;
 
 namespace UI.MainMenu.TournamentMode
 {
@@ -66,12 +67,23 @@ namespace UI.MainMenu.TournamentMode
 
         public DifficultyLevel GetDifficultyForRound()
         {
+            // Base Score -> 0 = Easy, 1 = Medium, 2 = Hard
+            float baseScore;
             if (CurrentRound.IsFirstRound())
-                return DifficultyLevel.Easy;
+                baseScore = 0f;
             else if (CurrentRound.IsLastRound() && NumberOfRounds > 2)
-                return DifficultyLevel.Hard;
+                baseScore = 2f;
             else
-                return DifficultyLevel.Medium;
+                baseScore = 1f;
+
+            // T is centered at 0.35. Below 0.35 pulls tiers down, above pushes them up.
+            float t = GameAndPlayerData.Instance != null ? GameAndPlayerData.Instance.T : 0.35f; // basically player's skill level, starts at 0.35
+            float shift = (t - 0.35f) * 2f;
+            float noise = Random.Range(-0.4f, 0.4f);
+            float score = Mathf.Clamp(baseScore + shift + noise, 0f, 2f);
+            if (score < 0.5f)  return DifficultyLevel.Easy;
+            if (score >= 1.5f) return DifficultyLevel.Hard;
+            return DifficultyLevel.Medium;
         }
     }
 }


### PR DESCRIPTION
Tournament difficulty still uses a mostly linear curve, but 
- We now calculate the player's overall skill level 
    - Using an Elo system (like chess)
    - Plus their recent performance in today's games.
- Based on that skill level, we slightly adjust the difficulty of matches down to easy or up to hard
- Along with some random noise to keep things interesting.
- We can later updated the build to send us this data as analytics we can view on our end, maybe using Unity Analytics.

Tournaments are hard! So we've changed the goals required per tournament match to 3. 
- Whether you win or lose, you move on in 3 goals.
- If you lose, you can try again and might just win.
