### PR TITLE
Saving on WebGL + Retry/quit is now tracked under tournament match analytics event

### DIFF
--- a/Assets/Scripts/Gameplay/Managers/MatchManager.cs
+++ b/Assets/Scripts/Gameplay/Managers/MatchManager.cs
@@ -25,6 +25,7 @@ namespace Gameplay.Managers
         
         Match _match;
         float _matchStartTime;
+        MatchEndedEvent _pendingMatchEndedEvent;
 
         int _leftScore, _rightScore;
         public void ResetGame()
@@ -39,8 +40,18 @@ namespace Gameplay.Managers
             TimeScaleManager.SetGameplayTimeScale();
         }
 
-        public void EndGame()
+        public void EndGame(bool retried = false)
         {
+#if UNITY_EDITOR == false
+            if (_pendingMatchEndedEvent != null)
+            {
+                _pendingMatchEndedEvent.Retried = retried;
+                AnalyticsService.Instance.RecordEvent(_pendingMatchEndedEvent); // sends to unity dashboard, ask Rishi
+                Debug.Log("sent match ended event to analytics");
+                _pendingMatchEndedEvent = null;
+            }
+#endif
+
             DOTween.KillAll();
 
             TimeScaleManager.SetDefaultTimeScale();
@@ -174,8 +185,17 @@ namespace Gameplay.Managers
                     MatchDuration = Mathf.RoundToInt(Time.time - _matchStartTime),
                     PlayerSkillRating = Mathf.RoundToInt(100f * (data != null ? data.T : 0.35f))
                 };
-                AnalyticsService.Instance.RecordEvent(analyticsEvent); // sends to unity dashboard, ask Rishi
-                Debug.Log("sent match ended event to analytics");
+
+                if (_match.IsPlayerWinner)
+                {
+                    AnalyticsService.Instance.RecordEvent(analyticsEvent);
+                    //Debug.Log("sent match ended event to analytics");
+                }
+                else
+                {
+                    // On loss, event only gets sent once we choose retry or quit.
+                    _pendingMatchEndedEvent = analyticsEvent;
+                }
             }
 #endif
 

--- a/Assets/Scripts/SaveSystem/JsonToFileStorageService.cs
+++ b/Assets/Scripts/SaveSystem/JsonToFileStorageService.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
@@ -9,48 +10,62 @@ namespace SaveSystem
     {
         public void Save(string key, object data, Action<bool> callback = null)
         {
+            JsonSerializerSettings settings = MakeSerializerSettings();
+            string json = JsonConvert.SerializeObject(data, settings);
+            string timestamp = DateTime.UtcNow.ToString("o");
+
+            bool fileSaved = SaveToFile(key, json);
+            bool prefsSaved = SaveToPlayerPrefs(key, json, timestamp);
+
+            callback?.Invoke(fileSaved || prefsSaved);
+        }
+
+        #region save helpers
+        private bool SaveToFile(string key, string json)
+        {
             try
             {
                 string path = BuildPath(key);
-                JsonSerializerSettings settings = MakeSerializerSettings();
-                string json = JsonConvert.SerializeObject(data, settings);
-
                 using (var fileStream = new StreamWriter(path))
                 {
                     fileStream.Write(json);
                 }
 
-                callback?.Invoke(true);
 #if UNITY_EDITOR
                 Debug.Log($"Game saved successfuly to {path}");
 #endif
+                return true;
             }
             catch (Exception e)
             {
                 LogException(e);
-                callback?.Invoke(false);
+                return false;
             }
         }
+
+        private bool SaveToPlayerPrefs(string key, string json, string timestamp)
+        {
+            try
+            {
+                PlayerPrefs.SetString(key, json);
+                PlayerPrefs.SetString(BuildTimestampKey(key), timestamp);
+                PlayerPrefs.Save();
+                return true;
+            }
+            catch (Exception e)
+            {
+                LogException(e);
+                return false;
+            }
+        }
+        #endregion
 
 
         public void Load<T>(string key, Action<T> callback)
         {
             try
             {
-                string path = BuildPath(key);
-
-                if (!File.Exists(path))
-                {
-#if UNITY_EDITOR
-                    Debug.LogWarning($"File not found: {path}");
-#endif
-                    callback?.Invoke(default);
-                    return;
-                }
-
-                JsonSerializerSettings settings = MakeSerializerSettings();
-
-                callback?.Invoke(ReadFile<T>(path, settings));
+                callback?.Invoke(Load<T>(key));
             }
             catch (Exception e)
             {
@@ -61,21 +76,91 @@ namespace SaveSystem
 
         public T Load<T>(string key)
         {
+            JsonSerializerSettings settings = MakeSerializerSettings();
+
+            DateTime? fileTimestamp = TryGetFileTimestamp(key);
+            DateTime? prefsTimestamp = TryGetPlayerPrefsTimestamp(key);
+
+            if (!fileTimestamp.HasValue && !prefsTimestamp.HasValue)
+            {
+#if UNITY_EDITOR
+                Debug.LogWarning($"No save data found for key: {key}");
+#endif
+                return default;
+            }
+
+            bool usePrefs = prefsTimestamp.HasValue && (!fileTimestamp.HasValue || prefsTimestamp.Value > fileTimestamp.Value);
+
+            if (usePrefs)
+            {
+                T prefsResult = TryLoadFromPlayerPrefs<T>(key, settings);
+                if (!EqualityComparer<T>.Default.Equals(prefsResult, default))
+                    return prefsResult;
+
+                // Fall back to file IO saving if PlayerPrefs deserialization failed.
+                return fileTimestamp.HasValue ? TryLoadFromFile<T>(key, settings) : default;
+            }
+
+            T fileResult = TryLoadFromFile<T>(key, settings);
+            if (!EqualityComparer<T>.Default.Equals(fileResult, default))
+                return fileResult;
+
+            // Fall back to PlayerPrefs if file IO deserialization failed.
+            return prefsTimestamp.HasValue ? TryLoadFromPlayerPrefs<T>(key, settings) : default;
+        }
+
+        #region helpers
+        private DateTime? TryGetFileTimestamp(string key)
+        {
             try
             {
                 string path = BuildPath(key);
+                return File.Exists(path) ? File.GetLastWriteTimeUtc(path) : (DateTime?)null;
+            }
+            catch (Exception e)
+            {
+                LogException(e);
+                return null;
+            }
+        }
 
-                if (!File.Exists(path))
-                {
-#if UNITY_EDITOR
-                    Debug.LogWarning($"File not found: {path}");
-#endif
-                    return default;
-                }
+        private DateTime? TryGetPlayerPrefsTimestamp(string key)
+        {
+            try
+            {
+                string timestampKey = BuildTimestampKey(key);
+                if (!PlayerPrefs.HasKey(key) || !PlayerPrefs.HasKey(timestampKey))
+                    return null;
 
-                JsonSerializerSettings settings = MakeSerializerSettings();
+                return ParseTimestamp(PlayerPrefs.GetString(timestampKey));
+            }
+            catch (Exception e)
+            {
+                LogException(e);
+                return null;
+            }
+        }
 
-                return ReadFile<T>(path, settings);
+        private T TryLoadFromFile<T>(string key, JsonSerializerSettings settings)
+        {
+            try
+            {
+                string path = BuildPath(key);
+                return File.Exists(path) ? ReadFile<T>(path, settings) : default;
+            }
+            catch (Exception e)
+            {
+                LogException(e);
+                return default;
+            }
+        }
+
+        private T TryLoadFromPlayerPrefs<T>(string key, JsonSerializerSettings settings)
+        {
+            try
+            {
+                string json = PlayerPrefs.GetString(key);
+                return JsonConvert.DeserializeObject<T>(json, settings);
             }
             catch (Exception e)
             {
@@ -111,13 +196,26 @@ namespace SaveSystem
         {
             return Path.Combine(Application.persistentDataPath, key);
         }
+        private string BuildTimestampKey(string key)
+        {
+            return key + "_timestamp";
+        }
+        private DateTime? ParseTimestamp(string timestamp)
+        {
+            if (DateTime.TryParse(timestamp, null, System.Globalization.DateTimeStyles.RoundtripKind, out DateTime result))
+            {
+                return result;
+            }
+            return null;
+        }
         private void LogException(Exception e)
         {
-            #if UNITY_EDITOR
-                Debug.LogError($"Save error: {e.Message}");
-            #else
+#if UNITY_EDITOR
+            Debug.LogError($"Save error: {e.Message}");
+#else
                 Debug.LogWarning($"Save error: {e.Message}");
-            #endif
+#endif
         }
+        #endregion
     }
 }

--- a/Assets/Scripts/SkillTracking/MatchEndedEvent.cs
+++ b/Assets/Scripts/SkillTracking/MatchEndedEvent.cs
@@ -30,4 +30,9 @@ public sealed class MatchEndedEvent : Event
     {
         set => SetParameter("player_skill_rating", value);
     }
+
+    public bool Retried
+    {
+        set => SetParameter("tournament_retried", value);
+    }
 }

--- a/Assets/Scripts/UI/UiSystem/Core/TournamentKnockOutView.cs
+++ b/Assets/Scripts/UI/UiSystem/Core/TournamentKnockOutView.cs
@@ -10,7 +10,7 @@ namespace UI.UiSystem.Core
     public class TournamentKnockOutView : UIView
     {
         [SerializeField] Button _playAgainButton, _mainMenuButton;
-        
+
         MatchManager _matchManager;
 
         [Header("Customization")]
@@ -23,23 +23,30 @@ namespace UI.UiSystem.Core
             base.Awake();
             _matchManager = FindFirstObjectByType<MatchManager>();
         }
-        
+
         void Start()
         {
             CustomizeCharacters();
             _playAgainButton.onClick.AddListener(OnPlayAgainClicked);
-            _mainMenuButton.onClick.AddListener(_matchManager.EndGame);
+            _mainMenuButton.onClick.AddListener(OnMainMenuClicked);
         }
 
         void OnPlayAgainClicked()
         {
             MatchFlow.Match.IsPlayAgain = true;
-            _matchManager.EndGame();
+            _matchManager.EndGame(true);
         }
+
+        void OnMainMenuClicked()
+        {
+            _matchManager.EndGame(false);
+        }
+
         void CustomizeCharacters()
         {
-            _customization1.SetCountryOutfit(_teamsData.GetTeamById(MatchFlow.Match.Settings.LeftCountryImageIndex));
-            _customization2.SetCountryOutfit(_teamsData.GetTeamById(MatchFlow.Match.Settings.LeftCountryImageIndex));
+            var leftTeam = _teamsData.GetTeamById(MatchFlow.Match.Settings.LeftCountryImageIndex);
+            _customization1.SetCountryOutfit(leftTeam);
+            _customization2.SetCountryOutfit(leftTeam);
         }
     }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -15,14 +15,14 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "24a73cbea943a23a737056e2771cae1401426fe6"
+      "hash": "95adbfddb055abda78a2b0c6969c7858e6626f24"
     },
     "com.invictus.art.tournament": {
       "version": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets/Tournament#main",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "24a73cbea943a23a737056e2771cae1401426fe6"
+      "hash": "95adbfddb055abda78a2b0c6969c7858e6626f24"
     },
     "com.unity.2d.animation": {
       "version": "10.2.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,19 +1,5 @@
 {
   "dependencies": {
-    "com.invictus.art.common": {
-      "version": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets/Common#main",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "8914eaa50469a87abaed0f629d6c2e667501257c"
-    },
-    "com.invictus.art.tournament": {
-      "version": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets/Tournament#main",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "8914eaa50469a87abaed0f629d6c2e667501257c"
-    },
     "com.coffee.ui-particle": {
       "version": "https://github.com/mob-sakai/ParticleEffectForUGUI.git",
       "depth": 0,
@@ -23,6 +9,20 @@
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "hash": "51a4708b7ba4daa8483a4936eae9bffe15d0bfd0"
+    },
+    "com.invictus.art.common": {
+      "version": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets/Common#main",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "24a73cbea943a23a737056e2771cae1401426fe6"
+    },
+    "com.invictus.art.tournament": {
+      "version": "https://github.com/Gamesforlove/Kickling-Art.git?path=/KicklingsArt/Assets/Runtime-Assets/Tournament#main",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "24a73cbea943a23a737056e2771cae1401426fe6"
     },
     "com.unity.2d.animation": {
       "version": "10.2.2",
@@ -271,6 +271,28 @@
       "depth": 2,
       "source": "registry",
       "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.services.analytics": {
+      "version": "6.3.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0",
+        "com.unity.services.core": "1.16.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.services.core": {
+      "version": "1.16.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.androidjni": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.2.1",
+        "com.unity.modules.unitywebrequest": "1.0.0"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {


### PR DESCRIPTION
- Saving now happens across player prefs and file IO, and is prioritized by date. Everything is wrapped in try catches, and player prefs is the preferred choice for webgl persistence. This already works for the ELO system on the tournament builds, and the file IO option is just a backup.
- New analytics parameter -- track if player chooses to retry or quit on tournament match lost. So now, on loss the 'match ended' event fires once you choose either retry or quit. If won, match ended event fires immediately. So we still fire one event, but get new info out of it.
